### PR TITLE
Koncentrator update response and minor fixes

### DIFF
--- a/src/koncentrator/module_api/module.py
+++ b/src/koncentrator/module_api/module.py
@@ -29,9 +29,9 @@ class Module:
     def get_content(self):
         try:
             req = requests.get("http://{0}:{1}/content".format(self.module_name, "80"))
-            if req.status_code == 200:
-                return req.content
         except:
-            utils.remove_module(self.module_id)
-            return "<html>Error !</html>"
+            req = None
+        if req is not None and req.status_code == 200:
+            return req.content
         utils.remove_module(self.module_id)
+        return "<html>Error !</html>"

--- a/src/koncentrator/view_api/view.py
+++ b/src/koncentrator/view_api/view.py
@@ -22,4 +22,4 @@ def get_content(module_id):
     if module is not None:
         return module.get_content()
     else:
-        return "<html>No module found</html>"
+        return "<html>No module found</html>", 404


### PR DESCRIPTION
Update Koncentrator status code when pulling a module that does not exist anymore. The Koncentrator now returns a `404` status code in that case instead of `200`.
Add a little fix on error checking when pulling modules.
