### PR TITLE
Fix multiple register

### DIFF
--- a/src/koncentrator/module_api/module.py
+++ b/src/koncentrator/module_api/module.py
@@ -14,6 +14,9 @@ def register_module():
     dict = request.json
     current_app.logger.debug(request.json)
     current_app.logger.debug("Got connection from: %s", dict['name'])
+    if utils.name_is_taken(dict['name']):
+        dict['success'] = False
+        return jsonify(dict), 403
     module = Module(dict)
     utils.add_module(module)
     answer = {}

--- a/src/koncentrator/utils/utils.py
+++ b/src/koncentrator/utils/utils.py
@@ -19,6 +19,13 @@ def get_module(module_id=None, token=None):
                 return modules[id]
     return None
 
+def name_is_taken(module_name):
+    global modules
+    for module_id in modules:
+        if modules[module_id].module_name == module_name:
+            return True
+    return False
+
 def remove_module(module_id):
     global modules
     if module_id in modules:

--- a/src/koncentrator/utils/utils.py
+++ b/src/koncentrator/utils/utils.py
@@ -19,12 +19,12 @@ def get_module(module_id=None, token=None):
                 return modules[id]
     return None
 
-def name_is_taken(module_name):
+def get_module_by_name(module_name):
     global modules
     for module_id in modules:
         if modules[module_id].module_name == module_name:
-            return True
-    return False
+            return modules[module_id]
+    return None
 
 def remove_module(module_id):
     global modules

--- a/src/modules/wikipedia-random/app.py
+++ b/src/modules/wikipedia-random/app.py
@@ -22,6 +22,8 @@ def loop():
 if __name__ == '__main__':
     out = requests.post('http://koncentrator:80/module/register',
             json={"name":"wikipedia-random","push":True,"expiration":1000})
+    if out.status_code != 200:
+        exit(1)
     dict = out.json()
     print(dict)
     thread = threading.Thread(target=loop, daemon=True)


### PR DESCRIPTION
These changes prevent a module to use a name already registered. Indeed, it was previously possible that two modules with the same name register with the same name. In order to avoid this situation, the Koncentrator now checks if the module with this name is already running.
